### PR TITLE
feat!: change secret and container names

### DIFF
--- a/charts/cactus-backend/Chart.yaml
+++ b/charts/cactus-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus-backend
 description: A web server for the Cactus backend that exposes an API for the Cactus app to use.
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "0.1"
 maintainers:
   - name: dataviruset

--- a/charts/cactus-backend/templates/statefulset.yaml
+++ b/charts/cactus-backend/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "cactus-backend.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}{{ if .Values.client }}-{{ .Values.client }}{{ end }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
@@ -70,7 +70,7 @@ spec:
         {{- if .Values.generalConfigKey }}
         - name: general-config
           secret:
-            secretName: {{ .Chart.Name }}
+            secretName: {{ include "cactus-backend.name" . }}
             items:
             - key: {{ .Values.generalConfigKey }}
               path: config.json
@@ -78,7 +78,7 @@ spec:
         {{- if .Values.clientParserConfigKey }}
         - name: client-parser-config
           secret:
-            secretName: {{ .Chart.Name }}
+            secretName: {{ include "cactus-backend.name" . }}
             items:
             - key: {{ .Values.clientParserConfigKey }}
               path: config.json


### PR DESCRIPTION
This is needed so the name overrides can be used to deploy different applications using this chart and separate secrets.
I define this as a breaking change as it will require renaming of the secrets that have been provisioned in Kubernetes outside of the chart (not managed by the chart).