### PR TITLE
feat(cactus-backend): configmap for domain mappings

### DIFF
--- a/charts/cactus-backend/Chart.yaml
+++ b/charts/cactus-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus-backend
 description: A backend that exposes an API for the Cactus app to use.
 type: application
-version: 0.5.4
+version: 0.5.6
 appVersion: "0.2"
 maintainers:
   - name: dataviruset

--- a/charts/cactus-backend/templates/configmap.yaml
+++ b/charts/cactus-backend/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cactus-backend.fullname" . }}-config
+  name: {{ include "cactus-backend.fullname" . }}-config-files
   labels:
     {{- include "cactus-backend.labels" . | nindent 4 }}
 data:

--- a/charts/cactus-backend/templates/configmap.yaml
+++ b/charts/cactus-backend/templates/configmap.yaml
@@ -6,8 +6,5 @@ metadata:
   labels:
     {{- include "cactus-backend.labels" . | nindent 4 }}
 data:
-  {{- range $filename, $content := .Values.configFiles.files }}
-  {{ $filename }}: |
-    {{- $content | nindent 4 }}
-  {{- end }}
+  {{- toYaml .Values.configFiles.files | nindent 2 }}
 {{- end }}

--- a/charts/cactus-backend/templates/configmap.yaml
+++ b/charts/cactus-backend/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configFiles.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cactus-backend.fullname" . }}-config
+  labels:
+    {{- include "cactus-backend.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.configFiles.files }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cactus-backend/templates/workload.yaml
+++ b/charts/cactus-backend/templates/workload.yaml
@@ -69,6 +69,10 @@ spec:
             - name: {{ ternary .Values.persistentVolume.statefulSetNameOverride "storage-volume" (and .Values.persistentVolume.enabled (not (empty .Values.persistentVolume.statefulSetNameOverride))) }}
               mountPath: /app/data
               subPath: "{{ .Values.persistentVolume.subPath }}"
+          {{- if .Values.configFiles.enabled }}
+            - name: config-files
+              mountPath: {{ .Values.configFiles.filePath }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}
@@ -111,7 +115,24 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.persistentVolume.enabled }}
+  {{- if or (not (and (eq .Values.kind "StatefulSet") .Values.persistentVolume.enabled)) .Values.configFiles.enabled }}
+      volumes:
+      {{- if not (and (eq .Values.kind "StatefulSet") .Values.persistentVolume.enabled) }}
+        - name: storage-volume
+          emptyDir:
+          {{- if .Values.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
+          {{- else }}
+            sizeLimit: 8Gi
+          {{- end }}
+      {{- end }}
+      {{- if .Values.configFiles.enabled }}
+        - name: config-files
+          configMap:
+            name: {{ include "cactus-backend.fullname" . }}-config
+      {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.kind "StatefulSet") .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: {{ .Values.persistentVolume.statefulSetNameOverride | default "storage-volume" }}
@@ -136,13 +157,4 @@ spec:
         storageClassName: "{{ .Values.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
-  {{- else }}
-      volumes:
-        - name: storage-volume
-          emptyDir:
-          {{- if .Values.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
-          {{- else }}
-            sizeLimit: 8Gi
-          {{- end -}}
-{{- end }}
+  {{- end }}

--- a/charts/cactus-backend/templates/workload.yaml
+++ b/charts/cactus-backend/templates/workload.yaml
@@ -120,16 +120,12 @@ spec:
       {{- if not (and (eq .Values.kind "StatefulSet") .Values.persistentVolume.enabled) }}
         - name: storage-volume
           emptyDir:
-          {{- if .Values.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
-          {{- else }}
-            sizeLimit: 8Gi
-          {{- end }}
+            sizeLimit: {{ .Values.emptyDir.sizeLimit | default "8Gi" }}
       {{- end }}
       {{- if .Values.configFiles.enabled }}
         - name: config-files
           configMap:
-            name: {{ include "cactus-backend.fullname" . }}-config
+            name: {{ include "cactus-backend.fullname" . }}-config-files
       {{- end }}
   {{- end }}
   {{- if and (eq .Values.kind "StatefulSet") .Values.persistentVolume.enabled }}

--- a/charts/cactus-backend/templates/workload.yaml
+++ b/charts/cactus-backend/templates/workload.yaml
@@ -17,11 +17,15 @@ metadata:
   labels:
     {{- include "cactus-backend.labels" . | nindent 4 }}
 spec:
+{{- if eq .Values.kind "Deployment" }}
+  replicas: {{ .Values.replicaCount | default 2 }}
+{{- end }}
+{{- if eq .Values.kind "StatefulSet" }}
   serviceName: {{ include "cactus-backend.fullname" . }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "cactus-backend.selectorLabels" . | nindent 6 }}
-  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -114,7 +114,7 @@ secrets:
   #   - key: secret-key
   #     envVarName: S3_SECRET_ACCESS_KEY
 
-kind: StatefulSet  # This is the kind of the resource to create. Use `Deployment` for production together with BLOB_STORAGE_TYPE=s3 and `StatefulSet` and BLOB_STORAGE_TYPE=local for development.
+kind: Deployment  # This is the kind of the resource to create. Use `Deployment` for production together with BLOB_STORAGE_TYPE=s3 and `StatefulSet` and BLOB_STORAGE_TYPE=local for development.
 
 persistentVolume:
   ## If true, create/use a Persistent Volume Claim, it only works when kind is StatefulSet
@@ -277,7 +277,7 @@ configFiles:
   files:
     domain_external_mappings.json: |
       {
-        "domain_id": "store_id",
+        "domain_id": "store_id"
       }
 
 envVars:

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -269,9 +269,21 @@ juicefs-s3-gateway:
 emptyDir:
   sizeLimit: 8Gi
 
+# Config files to create and mount into the container
+# When enabled, persistentVolume.enabled is ignored
+configFiles:
+  enabled: false
+  # Mount path for config files inside the container
+  filePath: /app/config
+  files:
+    domain_external_mappings.json: |
+      {
+        "domain_id": "store_id",
+      }
+
 envVars:
-  GATEWAY_PORT: 8080
-  GATEWAY_ADMIN_PORT: 18190
+  PORT: 8080
+  ADMIN_PORT: 18190
   ENV: prod  # Anything other than 'test'
   AUKI_API_URL: https://api.auki.network  # The URL of the AUKI API
   AUKI_DDS_URL: https://dds.auki.network  # The URL of the DDS
@@ -281,7 +293,6 @@ envVars:
   # sec   min   hour   day of month   month   day of week
   # *     *     *      *              *       *
   CRONJOBS_TAKE_SNAPSHOT_SCHEDULE: "0 0 16 * * *"  # The schedule for the cron job to take a snapshot of semantic shelves
-  FAKESTORE_URL: https://fakestore-backend.prod.lookingglassprotocol.com  # This will be used by default when no other backend is provided.
 
   POSTGRES_POOL_SIZE: 10  # The size of the postgres pool
   POSTGRES_POOL_IDLE_TIMEOUT: 2  # The idle timeout for the postgres pool in seconds. This is the time after which the connection will be closed if it is idle.
@@ -313,6 +324,8 @@ envVars:
   TOKEN_CACHE_TTL: 600  # The TTL for the token cache in seconds. This is the time after which the auth token will be REVERIFIED by the backend. Set to zero to disable caching.
 
   # APP_KEY: cactus-backend  # This is the app key used together with the app secret (defined in the secretData above or by using existingSecret) to access Auki services. You should obtain it from the apps section of the Auki console.
+  # PRODUCTS_URL: http://cactus-products:8080  # The URL of the Products API.
+  # SALES_URL: http://cactus-sales:8080  # The URL of the Sales API.
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -292,6 +292,7 @@ envVars:
   # sec   min   hour   day of month   month   day of week
   # *     *     *      *              *       *
   CRONJOBS_TAKE_SNAPSHOT_SCHEDULE: "0 0 16 * * *"  # The schedule for the cron job to take a snapshot of semantic shelves
+  FAKESTORE_URL: https://fakestore-backend.prod.lookingglassprotocol.com  # This will be used by default when no other backend is provided.
 
   POSTGRES_POOL_SIZE: 10  # The size of the postgres pool
   POSTGRES_POOL_IDLE_TIMEOUT: 2  # The idle timeout for the postgres pool in seconds. This is the time after which the connection will be closed if it is idle.
@@ -323,8 +324,6 @@ envVars:
   TOKEN_CACHE_TTL: 600  # The TTL for the token cache in seconds. This is the time after which the auth token will be REVERIFIED by the backend. Set to zero to disable caching.
 
   # APP_KEY: cactus-backend  # This is the app key used together with the app secret (defined in the secretData above or by using existingSecret) to access Auki services. You should obtain it from the apps section of the Auki console.
-  # PRODUCTS_URL: http://cactus-products:8080  # The URL of the Products API.
-  # SALES_URL: http://cactus-sales:8080  # The URL of the Sales API.
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -117,7 +117,7 @@ secrets:
 kind: StatefulSet  # This is the kind of the resource to create. Use `Deployment` for production together with BLOB_STORAGE_TYPE=s3 and `StatefulSet` and BLOB_STORAGE_TYPE=local for development.
 
 persistentVolume:
-  ## If true, create/use a Persistent Volume Claim
+  ## If true, create/use a Persistent Volume Claim, it only works when kind is StatefulSet
   ## If false, use emptyDir
   ##
   enabled: true
@@ -270,7 +270,6 @@ emptyDir:
   sizeLimit: 8Gi
 
 # Config files to create and mount into the container
-# When enabled, persistentVolume.enabled is ignored
 configFiles:
   enabled: false
   # Mount path for config files inside the container


### PR DESCRIPTION
- removed FAKESTORE_URL, added PRODUCTS_URL and SALES_URL https://www.notion.so/aukilabs/Replacing-the-fakestore-2b63a492266880e08da6e46d94f9a07d?source=copy_link#2cc3a492266880d692d8d8427001d197
- added configmap so we can mount domain-mappings.json https://github.com/matterless/cactus-backend/pull/60