### PR TITLE
fix: bump cactus parser chart version and disable OTel metric pushing by default

### DIFF
--- a/charts/cactus-backend/Chart.yaml
+++ b/charts/cactus-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus-backend
 description: A backend that exposes an API for the Cactus app to use.
 type: application
-version: 0.5.10
+version: 0.5.11
 appVersion: "0.2"
 maintainers:
   - name: dataviruset

--- a/charts/cactus-backend/Chart.yaml
+++ b/charts/cactus-backend/Chart.yaml
@@ -30,5 +30,5 @@ dependencies:
   condition: cactus-parser.enabled
 - name: opentelemetry-collector
   version: 0.143.0
-  condition: envVars.OTEL_ENABLED
+  condition: opentelemetry-collector.enabled
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/charts/cactus-backend/Chart.yaml
+++ b/charts/cactus-backend/Chart.yaml
@@ -25,10 +25,10 @@ dependencies:
   repository: https://juicedata.github.io/charts/
   condition: juicefs-s3-gateway.enabled
 - name: cactus-parser
-  version: 0.0.3
+  version: 0.0.5
   repository: https://charts.lookingglassprotocol.com
   condition: cactus-parser.enabled
 - name: opentelemetry-collector
   version: 0.143.0
-  condition: opentelemetry-collector.enabled
+  condition: envVars.OTEL_ENABLED
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/charts/cactus-backend/README.md
+++ b/charts/cactus-backend/README.md
@@ -130,9 +130,9 @@ Version 0.5.0 introduces significant changes to the feature set of the Cactus Ba
 
 ### Upgrading to 0.5.11
 
-#### Features
+#### Fixes
 
-* OpenTelemetry integration is disabled by default. To enable telemetry for both the Cactus Backend and Cactus Parser, set `cactus-backend.envVars.OTEL_ENABLED` and `cactus-backend.cactus-parser.envVars.OTEL_ENABLED` to `true` in your configuration.
+* OpenTelemetry integration is now disabled by default. To enable telemetry for both the Cactus Backend and Cactus Parser, set `cactus-backend.envVars.OTEL_ENABLED` and `cactus-backend.cactus-parser.envVars.OTEL_ENABLED` to `true` in your configuration. If you would like to use the OpenTelemetry sub-chart it can be enabled by setting `opentelemetry-collector.enable` to true just like before.
 
 ## Chart Structure
 

--- a/charts/cactus-backend/README.md
+++ b/charts/cactus-backend/README.md
@@ -132,7 +132,7 @@ Version 0.5.0 introduces significant changes to the feature set of the Cactus Ba
 
 #### Features
 
-* You can enable or disable OpenTelemetry for both the application and its dependencies as needed. To activate OpenTelemetry in both the Cactus Backend and the opentelemetry-collector dependency, set `cactus-backend.envVars.OTEL_ENABLED` to `true`.
+* OpenTelemetry can be toggled on or off as required. To enable it for both the Cactus Backend and Cactus Parser, set `cactus-backend.envVars.OTEL_ENABLED` and `cactus-backend.cactus-parser.envVars.OTEL_ENABLED` to `true`.
 
 ## Chart Structure
 

--- a/charts/cactus-backend/README.md
+++ b/charts/cactus-backend/README.md
@@ -132,7 +132,7 @@ Version 0.5.0 introduces significant changes to the feature set of the Cactus Ba
 
 #### Features
 
-* OpenTelemetry can be toggled on or off as required. To enable it for both the Cactus Backend and Cactus Parser, set `cactus-backend.envVars.OTEL_ENABLED` and `cactus-backend.cactus-parser.envVars.OTEL_ENABLED` to `true`.
+* OpenTelemetry integration is disabled by default. To enable telemetry for both the Cactus Backend and Cactus Parser, set `cactus-backend.envVars.OTEL_ENABLED` and `cactus-backend.cactus-parser.envVars.OTEL_ENABLED` to `true` in your configuration.
 
 ## Chart Structure
 

--- a/charts/cactus-backend/README.md
+++ b/charts/cactus-backend/README.md
@@ -63,7 +63,7 @@ To upgrade your deployment:
 helm upgrade cactus-backend matterless/cactus-backend
 ```
 
-**Important:**  
+**Important:**
 Before upgrading from chart version please review the following steps:
 
 1. **Review the [values.yaml](./values.yaml) file** for any new, deprecated, or changed configuration options.
@@ -127,6 +127,12 @@ Version 0.5.0 introduces significant changes to the feature set of the Cactus Ba
   * To monitor these services with Azure Application Insights, refer to the [Azure Monitor Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter).
   * For Prometheus integration, enable `podMonitor` and the `prometheus` port, and see the [Spanmetrics Connector for Prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector).
   * For additional configuration details, consult the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector).
+
+### Upgrading to 0.5.11
+
+#### Features
+
+* You can enable or disable OpenTelemetry for both the application and its dependencies as needed. To activate OpenTelemetry in both the Cactus Backend and the opentelemetry-collector dependency, set `cactus-backend.envVars.OTEL_ENABLED` to `true`.
 
 ## Chart Structure
 

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -340,7 +340,6 @@ envVars:
 
   # APP_KEY: cactus-backend  # This is the app key used together with the app secret (defined in the secretData above or by using existingSecret) to access Auki services. You should obtain it from the apps section of the Auki console.
   OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-backend-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
-  OTEL_ENABLED: false
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 autoscaling:

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -292,6 +292,7 @@ configFiles:
 envVars:
   PORT: 8080
   ADMIN_PORT: 18190
+  OTEL_ENABLED: false
   ENV: prod  # Anything other than 'test'
   AUKI_API_URL: https://api.auki.network  # The URL of the AUKI API
   AUKI_DDS_URL: https://dds.auki.network  # The URL of the DDS
@@ -393,7 +394,6 @@ cactus-parser:
   envVars:
     OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-backend-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
 opentelemetry-collector:
-  enabled: false
   mode: deployment
   image:
     repository: otel/opentelemetry-collector-contrib

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -340,6 +340,7 @@ envVars:
 
   # APP_KEY: cactus-backend  # This is the app key used together with the app secret (defined in the secretData above or by using existingSecret) to access Auki services. You should obtain it from the apps section of the Auki console.
   OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-backend-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
+  OTEL_ENABLED: false
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 autoscaling:

--- a/charts/cactus-backend/values.yaml
+++ b/charts/cactus-backend/values.yaml
@@ -292,7 +292,6 @@ configFiles:
 envVars:
   PORT: 8080
   ADMIN_PORT: 18190
-  OTEL_ENABLED: false
   ENV: prod  # Anything other than 'test'
   AUKI_API_URL: https://api.auki.network  # The URL of the AUKI API
   AUKI_DDS_URL: https://dds.auki.network  # The URL of the DDS
@@ -341,6 +340,7 @@ envVars:
 
   # APP_KEY: cactus-backend  # This is the app key used together with the app secret (defined in the secretData above or by using existingSecret) to access Auki services. You should obtain it from the apps section of the Auki console.
   OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-backend-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
+  OTEL_ENABLED: false
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 autoscaling:
@@ -393,7 +393,9 @@ cactus-parser:
     enabled: false
   envVars:
     OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-backend-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
+    OTEL_ENABLED: false
 opentelemetry-collector:
+  enabled: false
   mode: deployment
   image:
     repository: otel/opentelemetry-collector-contrib

--- a/charts/cactus-parser/Chart.yaml
+++ b/charts/cactus-parser/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus-parser
 description: Used to deploy parsers that load product data from a source when requested from cactus-backend
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "0.0"
 maintainers:
   - name: dataviruset

--- a/charts/cactus-parser/values.yaml
+++ b/charts/cactus-parser/values.yaml
@@ -282,6 +282,7 @@ envVars:
   S3_PATH_PREFIX: cactus-parser  # The path prefix for the S3 bucket. This cannot be empty when blob storage type is s3.
 
   OTEL_COLLECTOR_GRPC_ENDPOINT: http://cactus-parser-opentelemetry-collector:4317  # The grpc endpoint for the opentelemetry collector, it should be Release.name-opentelemetry-collector:4317.
+  OTEL_ENABLED: false
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 autoscaling:


### PR DESCRIPTION
when opentelemetry dependency is disabled, application should not even try to export traces to it.
so we wont be spammed by errors
<img width="1579" height="119" alt="Screenshot 2026-02-02 at 18 34 26" src="https://github.com/user-attachments/assets/f935dad4-bebd-47d5-9513-4e92968d9697" />
