### PR TITLE
feat(cactus): add EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL, bump chart to 0.0.6

### DIFF
--- a/charts/cactus/Chart.yaml
+++ b/charts/cactus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus
 description: Cactus' web client that uses cactus-backend
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "1"
 maintainers:
   - name: shuninghuang

--- a/charts/cactus/README.md
+++ b/charts/cactus/README.md
@@ -76,9 +76,11 @@ deployment at a different retail-ops config. The variable is also registered in
 `entrypointEnvVars` so it gets substituted into the JS bundles at container startup.
 
 No action is required for existing deployments: older Cactus versions ignore the variable, and
-versions that support it fall back to the production URL when it is unset. Note that if you
-override the `entrypointEnvVars` list in a custom values file, you must add `RETAIL_OPS_CONFIG_URL`
-to your override for the variable to take effect.
+versions that support it fall back to the production URL whenever the value is unset or not
+substituted (an error is logged in the browser console). If you override the `entrypointEnvVars`
+list in a custom values file **and** want a non-default config URL, add `RETAIL_OPS_CONFIG_URL` to
+your list — otherwise your custom URL is never substituted into the JS bundles and the app quietly
+stays on the production fallback.
 
 ### Upgrading to 0.0.5
 

--- a/charts/cactus/README.md
+++ b/charts/cactus/README.md
@@ -65,6 +65,21 @@ Before upgrading, please review the following steps:
 4. **Backup:** If your deployment uses persistent data, ensure you have backups.
 5. **Test:** Consider upgrading in a staging environment before production.
 
+### Upgrading to 0.0.6
+
+**New environment variable: `EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL`.**
+
+The retail-ops client configuration URL is now configurable instead of being hardcoded to the
+production URL in the app. The chart defaults to the production config
+(`https://config.lookingglassprotocol.com/retail-ops.json`); override it in `envVars` to point a
+deployment at a different retail-ops config. The variable is also registered in
+`entrypointEnvVars` so it gets substituted into the JS bundles at container startup.
+
+No action is required for existing deployments: older Cactus versions ignore the variable, and
+versions that support it fall back to the production URL when it is unset. Note that if you
+override the `entrypointEnvVars` list in a custom values file, you must add `RETAIL_OPS_CONFIG_URL`
+to your override for the variable to take effect.
+
 ### Upgrading to 0.0.5
 
 **app key and secret removed from values.**

--- a/charts/cactus/values.yaml
+++ b/charts/cactus/values.yaml
@@ -156,12 +156,14 @@ entrypointEnvVars:
   - AUTH_ISSUER
   - AUTH_CLIENT_ID_WEB
   - JOYSTICK_API_KEY
+  - RETAIL_OPS_CONFIG_URL
 
 envVars:
   EXPO_PUBLIC_DDS_URL: "https://dds.auki.network/"
   EXPO_PUBLIC_API_URL: "https://api.auki.network/"
   EXPO_PUBLIC_AUTH_ISSUER: "https://auth.auki.network"
   EXPO_PUBLIC_AUTH_CLIENT_ID_WEB: ""  # Obtain from Auki
+  EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL: "https://config.lookingglassprotocol.com/retail-ops.json"
   EXPO_PUBLIC_AUKI_API_PROJECT_ID: "342480985197117780"
 
 useExistingSecret: false


### PR DESCRIPTION
Follow-up to matterless/cactus#106, which made the retail-ops client config URL configurable via `EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL` instead of a hardcoded production URL.

## Changes
- Add `EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL` to the chart's default `envVars`, defaulting to the production config (`https://config.lookingglassprotocol.com/retail-ops.json`).
- Register `RETAIL_OPS_CONFIG_URL` in `entrypointEnvVars` so the entrypoint script substitutes it into the JS bundles at container startup.
- Bump chart version to `0.0.6`.
- Add an "Upgrading to 0.0.6" section to the README.

## Notes
- Safe for existing deployments: older Cactus versions ignore the variable, and versions that support it fall back to the production URL when unset.
- Once released, the wrapper chart in matterless/cactus should bump its pinned dependency (currently `0.0.4`) — companion PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)