### PR TITLE
chore(cactus): drop dead AUKI_APP_KEY/SECRET from entrypointEnvVars, bump chart to 0.0.7

### DIFF
--- a/charts/cactus/Chart.yaml
+++ b/charts/cactus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cactus
 description: Cactus' web client that uses cactus-backend
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "1"
 maintainers:
   - name: shuninghuang

--- a/charts/cactus/README.md
+++ b/charts/cactus/README.md
@@ -65,6 +65,18 @@ Before upgrading, please review the following steps:
 4. **Backup:** If your deployment uses persistent data, ensure you have backups.
 5. **Test:** Consider upgrading in a staging environment before production.
 
+### Upgrading to 0.0.7
+
+**`AUKI_APP_KEY` / `AUKI_APP_SECRET` removed from `entrypointEnvVars`.**
+
+Cactus dropped app key/secret auth in v1.11.3 — DDS/DS now authenticate with the user's OAuth
+access token. The 0.0.5 chart removed the values, but the two names lingered in the default
+`entrypointEnvVars` list; they are now gone.
+
+No action is required: the substitution for them was already a no-op (nothing in the app reads
+them, so the placeholders are not present in the JS bundles). If you override `entrypointEnvVars`
+in a custom values file, you can drop `AUKI_APP_KEY` and `AUKI_APP_SECRET` from your list.
+
 ### Upgrading to 0.0.6
 
 **New environment variable: `EXPO_PUBLIC_RETAIL_OPS_CONFIG_URL`.**
@@ -86,7 +98,7 @@ stays on the production fallback.
 
 **app key and secret removed from values.**
 
-`EXPO_PUBLIC_AUKI_APP_KEY`, `EXPO_PUBLIC_AUKI_APP_SECRET` are no longer needed from Cactus v0.11.3.
+`EXPO_PUBLIC_AUKI_APP_KEY`, `EXPO_PUBLIC_AUKI_APP_SECRET` are no longer needed from Cactus v1.11.3.
 
 If you have been overriding these values, they are no longer recognized and should be removed from your custom values file.
 

--- a/charts/cactus/values.yaml
+++ b/charts/cactus/values.yaml
@@ -148,8 +148,6 @@ entrypointPrefixes:
 entrypointEnvVars:
   - API_URL
   - DDS_URL
-  - AUKI_APP_KEY
-  - AUKI_APP_SECRET
   - AUKI_API_PROJECT_ID
   - DS_URL
   - AMPLITUDE_PROD_API_KEY


### PR DESCRIPTION
## What
Removes the leftover `AUKI_APP_KEY` / `AUKI_APP_SECRET` wiring from the published `cactus` subchart's default `entrypointEnvVars`, and bumps the chart `0.0.6 → 0.0.7`.

## Why
Cactus dropped app key/secret DDS auth in **v1.11.3** — DDS/DS now authenticate with the user's Zitadel OAuth bearer token (plus the `AUKI_API_PROJECT_ID` audience scope). The env-var plumbing was never cleaned up. The deployment values were already cleaned in matterless/cactus#134 (merged + synced); this completes the migration in the customer-facing chart.

## Changes
- `values.yaml`: drop `AUKI_APP_KEY`, `AUKI_APP_SECRET` from the default `entrypointEnvVars`
- `Chart.yaml`: `0.0.6 → 0.0.7` (chart-releaser only publishes a version it hasn't released)
- `README.md`: add an "Upgrading to 0.0.7" note; fix a `v0.11.3 → v1.11.3` typo in the 0.0.5 note

## Impact
Functional no-op for Matterless — the umbrella chart already overrides `entrypointEnvVars`, so dev/staging/prod are unaffected. This is customer-facing hygiene (a self-hoster reading the chart shouldn't think app key/secret are still required). Blast radius for self-hosters: only someone who **both** doesn't override `entrypointEnvVars` **and** runs an image < v1.11.3 — and the entrypoint is null-safe, so nothing breaks even then.

## Verification
- `helm lint charts/cactus` passes
- `helm template` output no longer contains `AUKI_APP_KEY` / `AUKI_APP_SECRET`

Jira: [PL-42]
Follows: matterless/cactus#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
